### PR TITLE
Fix lint issues and update exception chaining

### DIFF
--- a/asyncio_functions/async_cancellable_task.py
+++ b/asyncio_functions/async_cancellable_task.py
@@ -42,10 +42,10 @@ async def async_cancellable_task(
         # Attempt to run the task with a timeout of 5 seconds
         result = await asyncio.wait_for(task(), timeout=5)
         return result
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         # If a timeout occurs, set the cancel event and raise a CancelledError
         cancel_event.set()
-        raise asyncio.CancelledError("Task was cancelled.")
+        raise asyncio.CancelledError("Task was cancelled.") from exc
 
 
 __all__ = ["async_cancellable_task"]

--- a/asyncio_functions/async_download.py
+++ b/asyncio_functions/async_download.py
@@ -51,8 +51,8 @@ async def async_download(url: str, dest_path: str, timeout: float = 30.0) -> Non
                 with open(dest_path, "wb") as f:
                     async for chunk in resp.content.iter_chunked(8192):
                         f.write(chunk)
-    except Exception as e:
-        raise RuntimeError(f"Download failed: {e}")
+    except Exception as exc:
+        raise RuntimeError(f"Download failed: {exc}") from exc
 
 
 __all__ = ["async_download"]

--- a/asyncio_functions/async_parallel_download.py
+++ b/asyncio_functions/async_parallel_download.py
@@ -94,8 +94,8 @@ async def async_parallel_download(
             with open(dest_path, "wb") as f:
                 for _, data in results:
                     f.write(data)
-    except Exception as e:
-        raise RuntimeError(f"Parallel download failed: {e}")
+    except Exception as exc:
+        raise RuntimeError(f"Parallel download failed: {exc}") from exc
 
 
 __all__ = ["async_parallel_download"]

--- a/compression_functions/binary_compression/compress_bz2.py
+++ b/compression_functions/binary_compression/compress_bz2.py
@@ -30,9 +30,11 @@ def compress_bz2(data: bytes) -> bytes:
         # Compress the data using bz2
         compressed: bytes = bz2.compress(data)
         return compressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_bz2"]

--- a/compression_functions/binary_compression/compress_gzip.py
+++ b/compression_functions/binary_compression/compress_gzip.py
@@ -42,9 +42,11 @@ def compress_gzip(data: bytes) -> bytes:
             gzip_file.write(data)
         # Return the compressed data
         return buffer.getvalue()
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_gzip"]

--- a/compression_functions/binary_compression/compress_lzma.py
+++ b/compression_functions/binary_compression/compress_lzma.py
@@ -30,9 +30,11 @@ def compress_lzma(data: bytes) -> bytes:
         # Compress the data using lzma
         compressed: bytes = lzma.compress(data)
         return compressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_lzma"]

--- a/compression_functions/binary_compression/compress_snappy.py
+++ b/compression_functions/binary_compression/compress_snappy.py
@@ -30,9 +30,11 @@ def compress_snappy(data: bytes) -> bytes:
         # Compress the data using Snappy
         compressed: bytes = snappy.compress(data)
         return compressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_snappy"]

--- a/compression_functions/binary_compression/compress_zlib.py
+++ b/compression_functions/binary_compression/compress_zlib.py
@@ -33,9 +33,11 @@ def compress_zlib(data: bytes) -> bytes:
         # Encode the compressed data with base64
         encoded: bytes = base64.b64encode(compressed)
         return encoded
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_zlib"]

--- a/compression_functions/binary_compression/compress_zstd.py
+++ b/compression_functions/binary_compression/compress_zstd.py
@@ -37,9 +37,11 @@ def compress_zstd(data: bytes, level: int = 3) -> bytes:
         # Compress the data using Zstandard
         compressed: bytes = compressor.compress(data)
         return compressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during compression
-        raise ValueError(f"An error occurred during compression: {e}")
+        raise ValueError(
+            f"An error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_zstd"]

--- a/compression_functions/binary_compression/decompress_bz2.py
+++ b/compression_functions/binary_compression/decompress_bz2.py
@@ -30,9 +30,11 @@ def decompress_bz2(compressed_data: bytes) -> bytes:
         # Decompress the data using bz2
         decompressed: bytes = bz2.decompress(compressed_data)
         return decompressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_bz2"]

--- a/compression_functions/binary_compression/decompress_gzip.py
+++ b/compression_functions/binary_compression/decompress_gzip.py
@@ -41,9 +41,11 @@ def decompress_gzip(compressed_data: bytes) -> bytes:
         with gzip.GzipFile(fileobj=buf, mode="rb") as f:
             # Read and return the decompressed data
             return f.read()
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_gzip"]

--- a/compression_functions/binary_compression/decompress_lzma.py
+++ b/compression_functions/binary_compression/decompress_lzma.py
@@ -30,9 +30,11 @@ def decompress_lzma(compressed_data: bytes) -> bytes:
         # Decompress the data using lzma
         decompressed: bytes = lzma.decompress(compressed_data)
         return decompressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_lzma"]

--- a/compression_functions/binary_compression/decompress_snappy.py
+++ b/compression_functions/binary_compression/decompress_snappy.py
@@ -30,9 +30,11 @@ def decompress_snappy(compressed_data: bytes) -> bytes:
         # Decompress the data using Snappy
         decompressed: bytes = snappy.decompress(compressed_data)
         return decompressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_snappy"]

--- a/compression_functions/binary_compression/decompress_zlib.py
+++ b/compression_functions/binary_compression/decompress_zlib.py
@@ -33,9 +33,11 @@ def decompress_zlib(compressed_data: bytes) -> bytes:
         # Decompress the data using zlib
         decompressed: bytes = zlib.decompress(compressed)
         return decompressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_zlib"]

--- a/compression_functions/binary_compression/decompress_zstd.py
+++ b/compression_functions/binary_compression/decompress_zstd.py
@@ -32,9 +32,11 @@ def decompress_zstd(compressed_data: bytes) -> bytes:
         # Decompress the data using Zstandard
         decompressed: bytes = decompressor.decompress(compressed_data)
         return decompressed
-    except Exception as e:
+    except Exception as exc:
         # Raise a ValueError if an error occurs during decompression
-        raise ValueError(f"An error occurred during decompression: {e}")
+        raise ValueError(
+            f"An error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_zstd"]

--- a/compression_functions/files_compression/compress_file_bz2.py
+++ b/compression_functions/files_compression/compress_file_bz2.py
@@ -62,9 +62,11 @@ def compress_file_bz2(input_file: str, output_file: str) -> None:
     except FileNotFoundError:
         # Re-raise file not found errors for callers to handle.
         raise
-    except (PermissionError, OSError) as e:
+    except (PermissionError, OSError) as exc:
         # Wrap all other I/O related errors in a generic OSError message.
-        raise OSError(f"An I/O error occurred during compression: {e}")
+        raise OSError(
+            f"An I/O error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_file_bz2"]

--- a/compression_functions/files_compression/compress_file_gzip.py
+++ b/compression_functions/files_compression/compress_file_gzip.py
@@ -47,8 +47,10 @@ def compress_file_gzip(input_file: str, output_file: str) -> None:
             shutil.copyfileobj(f_in, f_out)
     except FileNotFoundError:
         raise
-    except (PermissionError, OSError) as e:
-        raise OSError(f"An I/O error occurred during compression: {e}")
+    except (PermissionError, OSError) as exc:
+        raise OSError(
+            f"An I/O error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_file_gzip"]

--- a/compression_functions/files_compression/compress_file_lzma.py
+++ b/compression_functions/files_compression/compress_file_lzma.py
@@ -46,8 +46,10 @@ def compress_file_lzma(input_file: str, output_file: str) -> None:
             f_out.writelines(f_in)
     except FileNotFoundError:
         raise
-    except (PermissionError, OSError) as e:
-        raise OSError(f"An I/O error occurred during compression: {e}")
+    except (PermissionError, OSError) as exc:
+        raise OSError(
+            f"An I/O error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_file_lzma"]

--- a/compression_functions/files_compression/compress_tar.py
+++ b/compression_functions/files_compression/compress_tar.py
@@ -67,8 +67,10 @@ def compress_tar(input_path: str, output_tar: str) -> None:
                 tar.add(input_path, arcname=os.path.basename(input_path))
     except FileNotFoundError:
         raise
-    except (PermissionError, OSError) as e:
-        raise OSError(f"An I/O error occurred during compression: {e}")
+    except (PermissionError, OSError) as exc:
+        raise OSError(
+            f"An I/O error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_tar"]

--- a/compression_functions/files_compression/compress_zip.py
+++ b/compression_functions/files_compression/compress_zip.py
@@ -62,8 +62,10 @@ def compress_zip(input_path: str, output_zip: str) -> None:
                 zipf.write(input_path, arcname=os.path.basename(input_path))
     except FileNotFoundError:
         raise
-    except (PermissionError, OSError) as e:
-        raise OSError(f"An I/O error occurred during compression: {e}")
+    except (PermissionError, OSError) as exc:
+        raise OSError(
+            f"An I/O error occurred during compression: {exc}"
+        ) from exc
 
 
 __all__ = ["compress_zip"]

--- a/compression_functions/files_compression/decompress_file_bz2.py
+++ b/compression_functions/files_compression/decompress_file_bz2.py
@@ -50,12 +50,16 @@ def decompress_file_bz2(input_bz2: str, output_file: str) -> None:
             with open(output_file, "wb") as f_out:
                 # Write the contents of the input file to the output file
                 f_out.writelines(f_in)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Raise a FileNotFoundError if the input file does not exist
-        raise FileNotFoundError(f"The input file {input_bz2} does not exist.")
-    except OSError as e:
+        raise FileNotFoundError(
+            f"The input file {input_bz2} does not exist."
+        ) from exc
+    except OSError as exc:
         # Raise an IOError if an I/O error occurs during decompression
-        raise OSError(f"An I/O error occurred during decompression: {e}")
+        raise OSError(
+            f"An I/O error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_file_bz2"]

--- a/compression_functions/files_compression/decompress_file_gzip.py
+++ b/compression_functions/files_compression/decompress_file_gzip.py
@@ -51,12 +51,16 @@ def decompress_file_gzip(input_gzip: str, output_file: str) -> None:
             with open(output_file, "wb") as f_out:
                 # Copy the contents of the input file to the output file
                 shutil.copyfileobj(f_in, f_out)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Raise a FileNotFoundError if the input file does not exist
-        raise FileNotFoundError(f"The input file {input_gzip} does not exist.")
-    except OSError as e:
+        raise FileNotFoundError(
+            f"The input file {input_gzip} does not exist."
+        ) from exc
+    except OSError as exc:
         # Raise an IOError if an I/O error occurs during decompression
-        raise OSError(f"An I/O error occurred during decompression: {e}")
+        raise OSError(
+            f"An I/O error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_file_gzip"]

--- a/compression_functions/files_compression/decompress_file_lzma.py
+++ b/compression_functions/files_compression/decompress_file_lzma.py
@@ -50,12 +50,16 @@ def decompress_file_lzma(input_file: str, output_file: str) -> None:
             with open(output_file, "wb") as f_out:
                 # Write the contents of the input file to the output file
                 f_out.writelines(f_in)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Raise a FileNotFoundError if the input file does not exist
-        raise FileNotFoundError(f"The input file {input_file} does not exist.")
-    except OSError as e:
+        raise FileNotFoundError(
+            f"The input file {input_file} does not exist."
+        ) from exc
+    except OSError as exc:
         # Raise an IOError if an I/O error occurs during decompression
-        raise OSError(f"An I/O error occurred during decompression: {e}")
+        raise OSError(
+            f"An I/O error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_file_lzma"]

--- a/compression_functions/files_compression/decompress_file_tar.py
+++ b/compression_functions/files_compression/decompress_file_tar.py
@@ -61,12 +61,16 @@ def decompress_file_tar(input_tar: str, output_dir: str) -> None:
         with tarfile.open(input_tar, "r:gz") as tar:
             # Extract all files to the specified output directory
             tar.extractall(path=output_dir)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Raise a FileNotFoundError if the input tar file does not exist
-        raise FileNotFoundError(f"The input tar file {input_tar} does not exist.")
-    except OSError as e:
+        raise FileNotFoundError(
+            f"The input tar file {input_tar} does not exist."
+        ) from exc
+    except OSError as exc:
         # Raise an IOError if an I/O error occurs during decompression
-        raise OSError(f"An I/O error occurred during decompression: {e}")
+        raise OSError(
+            f"An I/O error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_file_tar"]

--- a/compression_functions/files_compression/decompress_file_zip.py
+++ b/compression_functions/files_compression/decompress_file_zip.py
@@ -46,12 +46,16 @@ def decompress_file_zip(input_zip: str, output_dir: str) -> None:
         with zipfile.ZipFile(input_zip, "r") as zipf:
             # Extract all files to the specified output directory
             zipf.extractall(output_dir)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Raise a FileNotFoundError if the input zip file does not exist
-        raise FileNotFoundError(f"The input zip file {input_zip} does not exist.")
-    except OSError as e:
+        raise FileNotFoundError(
+            f"The input zip file {input_zip} does not exist."
+        ) from exc
+    except OSError as exc:
         # Raise an IOError if an I/O error occurs during decompression
-        raise OSError(f"An I/O error occurred during decompression: {e}")
+        raise OSError(
+            f"An I/O error occurred during decompression: {exc}"
+        ) from exc
 
 
 __all__ = ["decompress_file_zip"]

--- a/compression_functions/polyline_decoding_list_of_ints.py
+++ b/compression_functions/polyline_decoding_list_of_ints.py
@@ -39,8 +39,10 @@ def polyline_decoding_list_of_ints(encoded_text: str) -> list[float]:
     while index < len(encoded_text):
         try:
             index, difference = decompress_number(encoded_text, index)
-        except Exception as e:
-            raise ValueError(f"Error decompressing number at index {index}: {e}")
+        except Exception as exc:
+            raise ValueError(
+                f"Error decompressing number at index {index}: {exc}"
+            ) from exc
 
         last_number += difference
         decoded_numbers.append(last_number)

--- a/data_types/hash_table.py
+++ b/data_types/hash_table.py
@@ -68,7 +68,7 @@ class HashTable(Generic[K, V]):
             The value associated with the key.
         """
         index = self._hash(key)
-        for i, (k, v) in enumerate(self.table[index]):
+        for i, (k, _value) in enumerate(self.table[index]):
             if k == key:
                 self.table[index][i] = (key, value)
                 return
@@ -114,7 +114,7 @@ class HashTable(Generic[K, V]):
             If the key is not found in the hash table.
         """
         index = self._hash(key)
-        for i, (k, v) in enumerate(self.table[index]):
+        for i, (k, _value) in enumerate(self.table[index]):
             if k == key:
                 del self.table[index][i]
                 return

--- a/data_validation/__init__.py
+++ b/data_validation/__init__.py
@@ -9,9 +9,6 @@ The module serves as a central hub for all data validation needs in the library.
 """
 
 # Import from submodules
-from .basic_validation import *
-
-# Re-export all functions for convenience
 from .basic_validation import (
     validate_collection,
     validate_email,
@@ -19,7 +16,6 @@ from .basic_validation import (
     validate_string,
     validate_type,
 )
-from .schema_validation import *
 from .schema_validation import (
     validate_cerberus_schema,
     validate_pydantic_schema,

--- a/data_validation/basic_validation/validate_email.py
+++ b/data_validation/basic_validation/validate_email.py
@@ -134,10 +134,10 @@ def validate_email(
     if not allow_unicode:
         try:
             email.encode("ascii")
-        except UnicodeEncodeError:
+        except UnicodeEncodeError as exc:
             raise ValueError(
                 f"{param_name} contains non-ASCII characters but allow_unicode=False"
-            )
+            ) from exc
 
     # Define regex patterns
     if allow_unicode:
@@ -186,14 +186,18 @@ def validate_email(
                     raise ValueError(
                         f"{param_name} domain does not have valid MX record"
                     )
-            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-                raise ValueError(f"{param_name} domain does not have valid MX record")
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as exc:
+                raise ValueError(
+                    f"{param_name} domain does not have valid MX record"
+                ) from exc
             except Exception:
                 # Fallback to A record check if MX check fails
                 try:
                     socket.gethostbyname(domain_part)
-                except socket.gaierror:
-                    raise ValueError(f"{param_name} domain does not exist")
+                except socket.gaierror as socket_error:
+                    raise ValueError(
+                        f"{param_name} domain does not exist"
+                    ) from socket_error
 
         except ImportError:
             # If dnspython is not available, use basic socket check
@@ -201,8 +205,8 @@ def validate_email(
                 import socket
 
                 socket.gethostbyname(domain_part)
-            except socket.gaierror:
-                raise ValueError(f"{param_name} domain does not exist")
+            except socket.gaierror as exc:
+                raise ValueError(f"{param_name} domain does not exist") from exc
 
 
 __all__ = ["validate_email"]

--- a/datetime_functions/convert_timezone.py
+++ b/datetime_functions/convert_timezone.py
@@ -49,8 +49,8 @@ def convert_timezone(
     if isinstance(to_timezone, str):
         try:
             to_tz = pytz.timezone(to_timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
-            raise ValueError(f"Unknown timezone: {to_timezone}")
+        except pytz.exceptions.UnknownTimeZoneError as exc:
+            raise ValueError(f"Unknown timezone: {to_timezone}") from exc
     else:
         to_tz = to_timezone
 
@@ -63,8 +63,8 @@ def convert_timezone(
         elif isinstance(from_timezone, str):
             try:
                 from_tz = pytz.timezone(from_timezone)
-            except pytz.exceptions.UnknownTimeZoneError:
-                raise ValueError(f"Unknown timezone: {from_timezone}")
+            except pytz.exceptions.UnknownTimeZoneError as exc:
+                raise ValueError(f"Unknown timezone: {from_timezone}") from exc
         else:
             from_tz = from_timezone
 

--- a/datetime_functions/format_date.py
+++ b/datetime_functions/format_date.py
@@ -45,5 +45,5 @@ def format_date(date_obj: datetime | date, format_string: str = "%Y-%m-%d") -> s
 
     try:
         return date_obj.strftime(format_string)
-    except ValueError as e:
-        raise ValueError(f"Invalid format string: {e}")
+    except ValueError as exc:
+        raise ValueError(f"Invalid format string: {exc}") from exc

--- a/datetime_functions/modify_days.py
+++ b/datetime_functions/modify_days.py
@@ -43,5 +43,5 @@ def modify_days(date_obj: datetime | date, days: int) -> datetime | date:
     try:
         delta = timedelta(days=days)
         return date_obj + delta
-    except (ValueError, OverflowError) as e:
-        raise ValueError(f"Invalid days value: {e}")
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(f"Invalid days value: {exc}") from exc

--- a/datetime_functions/modify_weeks.py
+++ b/datetime_functions/modify_weeks.py
@@ -27,5 +27,5 @@ def modify_weeks(date_obj: datetime | date, weeks: int) -> datetime | date:
     try:
         delta = timedelta(weeks=weeks)
         return date_obj + delta
-    except (ValueError, OverflowError) as e:
-        raise ValueError(f"Invalid weeks value: {e}")
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(f"Invalid weeks value: {exc}") from exc

--- a/decorators/cache.py
+++ b/decorators/cache.py
@@ -72,8 +72,8 @@ def cache(func: Callable[P, R]) -> Callable[P, R]:
             if key not in cached_results:
                 # If not cached, call the function and store the result
                 cached_results[key] = func(*args, **kwargs)
-        except TypeError as e:
-            raise TypeError(f"Unhashable arguments: {e}")
+        except TypeError as exc:
+            raise TypeError(f"Unhashable arguments: {exc}") from exc
 
         # Return the cached result
         return cached_results[key]

--- a/decorators/cache_with_expiration.py
+++ b/decorators/cache_with_expiration.py
@@ -85,8 +85,8 @@ def cache_with_expiration(
                         return cached_value
                 result = func(*args, **kwargs)
                 cached_results[key] = (current_time, result)
-            except TypeError as e:
-                raise TypeError(f"Unhashable arguments: {e}")
+            except TypeError as exc:
+                raise TypeError(f"Unhashable arguments: {exc}") from exc
 
             return result
 

--- a/decorators/chain.py
+++ b/decorators/chain.py
@@ -64,10 +64,10 @@ def chain(func: Callable[P, T]) -> Callable[P, T | Any]:
                         return chain_method()
                 else:
                     return chain_method(*args, **kwargs)
-            except Exception as e:
+            except Exception as exc:
                 raise RuntimeError(
-                    f"Error calling 'chain' method on result of {func.__name__}: {e}"
-                )
+                    f"Error calling 'chain' method on result of {func.__name__}: {exc}"
+                ) from exc
         return result
 
     return wrapper

--- a/decorators/conditional_execute.py
+++ b/decorators/conditional_execute.py
@@ -72,8 +72,10 @@ def conditional_execute(
             try:
                 if predicate():
                     return func(*args, **kwargs)
-            except Exception as e:
-                raise RuntimeError(f"Predicate function raised an error: {e}")
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Predicate function raised an error: {exc}"
+                ) from exc
             return None
 
         return wrapper

--- a/decorators/conditional_return.py
+++ b/decorators/conditional_return.py
@@ -74,8 +74,10 @@ def conditional_return(
             try:
                 if condition(*args, **kwargs):
                     return return_value
-            except Exception as e:
-                raise RuntimeError(f"Condition function raised an error: {e}")
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Condition function raised an error: {exc}"
+                ) from exc
             return func(*args, **kwargs)
 
         return wrapper

--- a/decorators/normalize_input.py
+++ b/decorators/normalize_input.py
@@ -77,17 +77,17 @@ def normalize_input(
                 normalized_kwargs = {
                     k: normalization_func(v) for k, v in kwargs.items()
                 }
-            except Exception as e:
-                message = f"Normalization failed: {e}"
+            except Exception as exc:
+                message = f"Normalization failed: {exc}"
                 if logger:
                     logger.error(message, exc_info=True)
-                raise TypeError(message)
+                raise TypeError(message) from exc
 
             try:
                 return func(*normalized_args, **normalized_kwargs)
-            except Exception as e:
+            except Exception as exc:
                 if logger:
-                    logger.error(str(e), exc_info=True)
+                    logger.error(str(exc), exc_info=True)
                 raise
 
         return wrapper

--- a/decorators/redirect_output.py
+++ b/decorators/redirect_output.py
@@ -74,11 +74,11 @@ def redirect_output(
             try:
                 with open(file_path, "w") as f, redirect_stdout(f):
                     return func(*args, **kwargs)
-            except Exception as e:
-                message = f"Failed to redirect output: {e}"
+            except Exception as exc:
+                message = f"Failed to redirect output: {exc}"
                 if logger:
                     logger.error(message, exc_info=True)
-                raise RuntimeError(message)
+                raise RuntimeError(message) from exc
 
         return wrapper
 

--- a/decorators/timeout.py
+++ b/decorators/timeout.py
@@ -93,7 +93,7 @@ def timeout(
                 future = executor.submit(_run_func)
                 try:
                     return future.result(timeout=seconds)
-                except FuturesTimeoutError:
+                except FuturesTimeoutError as exc:
                     message = (
                         f"Function {func.__name__} timed out after {seconds} seconds"
                     )
@@ -101,7 +101,7 @@ def timeout(
                         logger.error(message)
                     # Attempt to cancel but function may continue running in background
                     future.cancel()
-                    raise TimeoutException(message)
+                    raise TimeoutException(message) from exc
 
         return wrapper
 

--- a/env_config_functions/get_env_var.py
+++ b/env_config_functions/get_env_var.py
@@ -41,6 +41,6 @@ def get_env_var(
     if value is not None and cast is not None:
         try:
             return cast(value)
-        except Exception as e:
-            raise ValueError(f"Failed to cast env var {key}: {e}")
+        except Exception as exc:
+            raise ValueError(f"Failed to cast env var {key}: {exc}") from exc
     return value

--- a/iterable_functions/__init__.py
+++ b/iterable_functions/__init__.py
@@ -43,12 +43,12 @@ from .list_operations import (
     add_strings_to_subsets,
     check_if_all_elements_are_duplicates,
     divide_list_into_n_chunks,
+    find_duplicates,
     get_duplicates,
     get_unique_sublists,
     group_by,
     is_nested_list_empty,
     repeat_strings_in_a_list,
-    find_duplicates,
     sliding_window,
 )
 from .set_operations import (
@@ -63,13 +63,13 @@ from .set_operations import (
     get_subsets_of_size,
     get_unique_elements_across_sets,
     partition_set_by_predicate,
+    partition_set_by_sizes,
     partition_set_into_n_parts,
     set_cartesian_product,
     set_cartesian_product_as_list,
     set_power_set,
     set_power_set_as_lists,
     set_symmetric_difference,
-    partition_set_by_sizes,
 )
 from .type_operations import (
     has_element_of_type,

--- a/iterable_functions/dictionary_operations/dict_value_difference.py
+++ b/iterable_functions/dictionary_operations/dict_value_difference.py
@@ -40,9 +40,9 @@ def dict_value_difference(
     --------
     >>> dict1 = {'a': 1, 'b': 2, 'c': 3}
     >>> dict2 = {'a': 1, 'b': 5, 'd': 4}
-    >>> dict_difference(dict1, dict2)
+    >>> dict_value_difference(dict1, dict2)
     {'b': 5, 'd': 4}
-    >>> dict_difference(dict1, dict2, ignore_missing=True)
+    >>> dict_value_difference(dict1, dict2, ignore_missing=True)
     {'b': 5}
 
     Notes
@@ -84,4 +84,4 @@ def dict_value_difference(
     return differences
 
 
-__all__ = ["dict_difference"]
+__all__ = ["dict_value_difference"]

--- a/iterable_functions/list_comparison/all_match_lists.py
+++ b/iterable_functions/list_comparison/all_match_lists.py
@@ -29,8 +29,10 @@ def all_match_lists(list1: list[Any], list2: list[Any]) -> bool:
 
     try:
         return all(elem in list2 for elem in list1)
-    except TypeError as e:
-        raise TypeError(f"An element in the list cannot be compared: {e}")
+    except TypeError as exc:
+        raise TypeError(
+            f"An element in the list cannot be compared: {exc}"
+        ) from exc
 
 
 __all__ = ["all_match_lists"]

--- a/iterable_functions/list_comparison/any_match_lists.py
+++ b/iterable_functions/list_comparison/any_match_lists.py
@@ -29,8 +29,10 @@ def any_match_lists(list1: list[Any], list2: list[Any]) -> bool:
 
     try:
         return any(elem in list2 for elem in list1)
-    except TypeError as e:
-        raise TypeError(f"An element in the list cannot be compared: {e}")
+    except TypeError as exc:
+        raise TypeError(
+            f"An element in the list cannot be compared: {exc}"
+        ) from exc
 
 
 __all__ = ["any_match_lists"]

--- a/iterable_functions/set_operations/convert_set_elements_to_strings.py
+++ b/iterable_functions/set_operations/convert_set_elements_to_strings.py
@@ -25,8 +25,10 @@ def convert_set_elements_to_strings(input_set: set[Any]) -> set[str]:
 
     try:
         return {str(element) for element in input_set}
-    except Exception as e:
-        raise TypeError(f"An element in the set cannot be converted to a string: {e}")
+    except Exception as exc:
+        raise TypeError(
+            f"An element in the set cannot be converted to a string: {exc}"
+        ) from exc
 
 
 __all__ = ["convert_set_elements_to_strings"]

--- a/iterable_functions/set_operations/get_shared_elements.py
+++ b/iterable_functions/set_operations/get_shared_elements.py
@@ -34,8 +34,10 @@ def get_shared_elements(dict_: dict[str, list[T]]) -> list[T]:
     for sublist in dict_.values():
         try:
             all_elements.extend(sublist)
-        except TypeError as e:
-            raise TypeError(f"Sublist contains unhashable elements: {e}")
+        except TypeError as exc:
+            raise TypeError(
+                f"Sublist contains unhashable elements: {exc}"
+            ) from exc
 
     element_counts = Counter(all_elements)
     shared_elements = [elem for elem, count in element_counts.items() if count >= 2]

--- a/iterable_functions/set_operations/set_partition.py
+++ b/iterable_functions/set_operations/set_partition.py
@@ -1,11 +1,10 @@
-from collections.abc import Callable
-
 """
 Set partition utilities.
 
 This module provides utilities for partitioning sets into subsets.
 """
 
+from collections.abc import Callable
 from typing import TypeVar
 
 T = TypeVar("T")

--- a/iterable_functions/type_operations/safe_cast.py
+++ b/iterable_functions/type_operations/safe_cast.py
@@ -74,7 +74,7 @@ def safe_cast(value: Any, target_type: type[T], default: T | None = None) -> T |
 
     # Attempt type conversion
     try:
-        if target_type == bool:
+        if target_type is bool:
             # Special handling for boolean conversion
             if isinstance(value, str):
                 if value.lower() in ("true", "1", "yes", "on"):
@@ -84,23 +84,23 @@ def safe_cast(value: Any, target_type: type[T], default: T | None = None) -> T |
                 else:
                     raise ValueError(f"Cannot convert '{value}' to bool")
             return bool(value)
-        elif target_type == int:
+        elif target_type is int:
             # Handle string to int conversion
             if isinstance(value, str):
                 return int(float(value)) if "." in value else int(value)
             return int(value)
-        elif target_type == float:
+        elif target_type is float:
             return float(value)
-        elif target_type == str:
+        elif target_type is str:
             return str(value)
-        elif target_type == list:
+        elif target_type is list:
             if isinstance(value, (list, tuple)):
                 return list(value)
             elif hasattr(value, "__iter__"):
                 return list(value)
             else:
                 return [value]
-        elif target_type == tuple:
+        elif target_type is tuple:
             if isinstance(value, (list, tuple)):
                 return tuple(value)
             elif hasattr(value, "__iter__"):

--- a/json_functions/json_diff.py
+++ b/json_functions/json_diff.py
@@ -27,7 +27,7 @@ def json_diff(a: Any, b: Any, path: str = "") -> list[tuple[str, Any, Any]]:
     [('[1]', 2, 3)]
     """
     diffs = []
-    if type(a) != type(b):
+    if type(a) is not type(b):
         diffs.append((path, a, b))
         return diffs
     if isinstance(a, dict):

--- a/network_functions/get_default_gateway.py
+++ b/network_functions/get_default_gateway.py
@@ -15,7 +15,7 @@ def get_default_gateway() -> str:
     >>> get_default_gateway()
     '192.168.1.1'
     """
-    gws = psutil.net_if_stats()
+    psutil.net_if_stats()
     # This is a placeholder; for real gateway detection, use netifaces or parse 'ip route'
     return ""
 

--- a/network_functions/get_ipv6_addresses.py
+++ b/network_functions/get_ipv6_addresses.py
@@ -18,7 +18,7 @@ def get_ipv6_addresses() -> list[str]:
     ['fe80::1', '2001:db8::1']
     """
     ipv6_addrs = []
-    for iface, addrs in psutil.net_if_addrs().items():
+    for _iface, addrs in psutil.net_if_addrs().items():
         for addr in addrs:
             if addr.family == socket.AF_INET6:
                 ipv6_addrs.append(addr.address)

--- a/network_functions/resolve_hostname.py
+++ b/network_functions/resolve_hostname.py
@@ -33,7 +33,7 @@ def resolve_hostname(hostname: str) -> str:
         raise ValueError("hostname cannot be empty")
     try:
         return socket.gethostbyname(hostname)
-    except Exception as e:
-        raise ValueError(f"Could not resolve hostname: {e}")
+    except Exception as exc:
+        raise ValueError(f"Could not resolve hostname: {exc}") from exc
 
 __all__ = ["resolve_hostname"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,13 @@ testpaths = ["pytest/unit"]
 [tool.ruff]
 line-length = 88
 target-version = "py310"  # match lowest supported Python
+extend-exclude = ["venv", ".venv", "dist", "build", ".mypy_cache", ".ruff_cache"]
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "TID"]
 ignore = [
   "E501",  # formatter handles long lines
 ]
-extend-exclude = ["venv", ".venv", "dist", "build", ".mypy_cache", ".ruff_cache"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["python_utils"]

--- a/pytest/unit/iterable_functions/dictionary_operations/test_dict_diff.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_dict_diff.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-import pytest
 from iterable_functions.dictionary_operations.dict_diff import dict_diff
+
+import pytest
 
 
 def test_dict_diff_case_1_identical_dictionaries() -> None:

--- a/ssh_functions/ssh_check_connection.py
+++ b/ssh_functions/ssh_check_connection.py
@@ -72,10 +72,12 @@ def ssh_check_connection(
             "stderr": proc.stderr.strip(),
             "exit_code": proc.returncode,
         }
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"SSH connection timed out after {timeout} seconds")
-    except Exception as e:
-        raise RuntimeError(f"SSH connection failed: {e}")
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"SSH connection timed out after {timeout} seconds"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(f"SSH connection failed: {exc}") from exc
 
 
 __all__ = ["ssh_check_connection"]

--- a/ssh_functions/ssh_copy_file.py
+++ b/ssh_functions/ssh_copy_file.py
@@ -83,10 +83,12 @@ def ssh_copy_file(
             "stderr": proc.stderr.strip(),
             "exit_code": proc.returncode,
         }
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"SCP command timed out after {timeout} seconds")
-    except Exception as e:
-        raise RuntimeError(f"SCP command failed: {e}")
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"SCP command timed out after {timeout} seconds"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(f"SCP command failed: {exc}") from exc
 
 
 __all__ = ["ssh_copy_file"]

--- a/ssh_functions/ssh_execute_command.py
+++ b/ssh_functions/ssh_execute_command.py
@@ -77,10 +77,12 @@ def ssh_execute_command(
             "stderr": proc.stderr.strip(),
             "exit_code": proc.returncode,
         }
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"SSH command timed out after {timeout} seconds")
-    except Exception as e:
-        raise RuntimeError(f"SSH command failed: {e}")
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"SSH command timed out after {timeout} seconds"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(f"SSH command failed: {exc}") from exc
 
 
 __all__ = ["ssh_execute_command"]

--- a/ssh_functions/ssh_execute_script.py
+++ b/ssh_functions/ssh_execute_script.py
@@ -85,12 +85,14 @@ def ssh_execute_script(
             "stderr": proc.stderr.strip(),
             "exit_code": proc.returncode,
         }
-    except FileNotFoundError:
-        raise ValueError(f"Script file not found: {script_path}")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"SSH command timed out after {timeout} seconds")
-    except Exception as e:
-        raise RuntimeError(f"SSH command failed: {e}")
+    except FileNotFoundError as exc:
+        raise ValueError(f"Script file not found: {script_path}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"SSH command timed out after {timeout} seconds"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(f"SSH command failed: {exc}") from exc
 
 
 __all__ = ["ssh_execute_script"]


### PR DESCRIPTION
## Summary
- add explicit exception chaining across async, compression, IO, and network helpers to satisfy Ruff B904
- address lint warnings by cleaning imports, removing unused variables, and correcting metadata such as __all__ entries
- migrate Ruff configuration to the new `[tool.ruff.lint]` section to silence configuration warnings

## Testing
- ruff check .
- pytest *(fails: missing optional dependencies `snappy`, `pytz`, `cryptography` required by tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c97fc9b8208325b0bde1af3cef7792