### PR TITLE
Improve async cancellable task cancellation handling

### DIFF
--- a/asyncio_functions/async_cancellable_task.py
+++ b/asyncio_functions/async_cancellable_task.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
@@ -7,7 +8,9 @@ T = TypeVar("T")
 
 
 async def async_cancellable_task(
-    task: Callable[[], Awaitable[T]], cancel_event: asyncio.Event
+    task: Callable[[], Awaitable[T]],
+    cancel_event: asyncio.Event,
+    timeout: float | None = None,
 ) -> T:
     """
     Run an asynchronous task that can be cancelled.
@@ -18,16 +21,23 @@ async def async_cancellable_task(
         The asynchronous function to run.
     cancel_event : asyncio.Event
         The event used to signal cancellation.
+    timeout : float | None, optional
+        Maximum number of seconds to wait for the task to finish or for the
+        cancellation event to be set. If ``None`` (the default), wait
+        indefinitely.
 
     Returns
     -------
     T
-        The result of the task if completed before cancellation.
+        The result of the task if it completes before cancellation or timeout.
 
     Raises
     ------
     asyncio.CancelledError
-        If the task is cancelled.
+        If the cancellation event is set before the task completes.
+    asyncio.TimeoutError
+        If ``timeout`` is provided and the operation takes longer than the
+        specified number of seconds.
 
     Examples
     --------
@@ -36,16 +46,44 @@ async def async_cancellable_task(
     >>>     return "Completed"
     >>>
     >>> cancel_event = asyncio.Event()
-    >>> result = asyncio.run(async_cancellable_task(long_running_task, cancel_event))
+    >>> result = asyncio.run(
+    ...     async_cancellable_task(long_running_task, cancel_event, timeout=10)
+    ... )
     """
+    if cancel_event.is_set():
+        raise asyncio.CancelledError("Task was cancelled.")
+
+    task_future = asyncio.create_task(task())
+    cancel_future = asyncio.create_task(cancel_event.wait())
+    pending: set[asyncio.Task] = set()
+
     try:
-        # Attempt to run the task with a timeout of 5 seconds
-        result = await asyncio.wait_for(task(), timeout=5)
-        return result
-    except asyncio.TimeoutError as exc:
-        # If a timeout occurs, set the cancel event and raise a CancelledError
-        cancel_event.set()
-        raise asyncio.CancelledError("Task was cancelled.") from exc
+        done, pending = await asyncio.wait(
+            {task_future, cancel_future},
+            return_when=asyncio.FIRST_COMPLETED,
+            timeout=timeout,
+        )
+
+        if not done:
+            task_future.cancel()
+            cancel_future.cancel()
+            raise asyncio.TimeoutError("async_cancellable_task timed out.")
+
+        if cancel_future in done:
+            task_future.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task_future
+            raise asyncio.CancelledError("Task was cancelled.")
+
+        cancel_future.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cancel_future
+        return task_future.result()
+    finally:
+        for pending_future in pending:
+            pending_future.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pending_future
 
 
 __all__ = ["async_cancellable_task"]

--- a/pytest/unit/asyncio_functions/test_async_cancellable_task.py
+++ b/pytest/unit/asyncio_functions/test_async_cancellable_task.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from asyncio_functions.async_cancellable_task import async_cancellable_task
+
+
+@pytest.mark.asyncio
+async def test_async_cancellable_task_returns_result():
+    """Task result is returned when cancellation is not requested."""
+
+    cancel_event = asyncio.Event()
+
+    async def sample_task() -> str:
+        await asyncio.sleep(0.01)
+        return "completed"
+
+    result = await async_cancellable_task(sample_task, cancel_event)
+
+    assert result == "completed"
+
+
+@pytest.mark.asyncio
+async def test_async_cancellable_task_cancelled_when_event_set():
+    """The task is cancelled when the cancel event is triggered."""
+
+    cancel_event = asyncio.Event()
+
+    async def long_task() -> None:
+        await asyncio.sleep(0.1)
+
+    async def trigger_cancel() -> None:
+        await asyncio.sleep(0.01)
+        cancel_event.set()
+
+    cancel_trigger = asyncio.create_task(trigger_cancel())
+
+    with pytest.raises(asyncio.CancelledError):
+        await async_cancellable_task(long_task, cancel_event)
+
+    await cancel_trigger
+
+
+@pytest.mark.asyncio
+async def test_async_cancellable_task_timeout():
+    """A timeout raises asyncio.TimeoutError when reached first."""
+
+    cancel_event = asyncio.Event()
+
+    async def long_task() -> None:
+        await asyncio.sleep(0.1)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await async_cancellable_task(long_task, cancel_event, timeout=0.01)


### PR DESCRIPTION
## Summary
- update `async_cancellable_task` to coordinate task execution with a cancellation event and optional timeout
- ensure cancellation and timeout paths cleanly cancel pending futures and propagate task results
- add unit tests covering completion, cancellation, and timeout scenarios

## Testing
- pytest pytest/unit/asyncio_functions/test_async_cancellable_task.py


------
https://chatgpt.com/codex/tasks/task_e_68d18a15ade48325accb3bcee44750e1