### PR TITLE
Handle non-string input validation in parse_url

### DIFF
--- a/http_functions/parse_url.py
+++ b/http_functions/parse_url.py
@@ -21,8 +21,10 @@ def parse_url(url: str) -> dict[str, Any]:
 
     Raises
     ------
+    TypeError
+        If the provided URL is not a string.
     ValueError
-        If URL is invalid or empty.
+        If the URL string is empty or only whitespace.
 
     Examples
     --------
@@ -34,7 +36,10 @@ def parse_url(url: str) -> dict[str, Any]:
     >>> result['port']
     8080
     """
-    if not isinstance(url, str) or not url.strip():
+    if not isinstance(url, str):
+        raise TypeError("URL must be a string")
+
+    if not url.strip():
         raise ValueError("URL must be a non-empty string")
 
     parsed = urllib.parse.urlparse(url)


### PR DESCRIPTION
## Summary
- update `parse_url` to raise `TypeError` for non-string inputs and keep `ValueError` for blank strings
- document both raised exceptions in the function docstring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d1b96c9c83258659b312642f2621