### PR TITLE
Adjust query parameter validation

### DIFF
--- a/http_functions/get_query_params.py
+++ b/http_functions/get_query_params.py
@@ -19,8 +19,10 @@ def get_query_params(url: str) -> dict[str, list[str]]:
 
     Raises
     ------
+    TypeError
+        If ``url`` is not a string.
     ValueError
-        If URL is invalid.
+        If ``url`` is an empty or whitespace-only string.
 
     Examples
     --------
@@ -29,7 +31,10 @@ def get_query_params(url: str) -> dict[str, list[str]]:
     >>> get_query_params('https://example.com')
     {}
     """
-    if not isinstance(url, str) or not url.strip():
+    if not isinstance(url, str):
+        raise TypeError("URL must be a string")
+
+    if not url.strip():
         raise ValueError("URL must be a non-empty string")
 
     parsed = urllib.parse.urlparse(url)


### PR DESCRIPTION
## Summary
- raise a TypeError when the provided URL is not a string
- update the documentation to reflect the new validation behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d1ba3b9c8325a18aab50cdf596e8