### PR TITLE
Handle non-string URLs in http_get

### DIFF
--- a/http_functions/http_get.py
+++ b/http_functions/http_get.py
@@ -27,8 +27,10 @@ def http_get(
 
     Raises
     ------
+    TypeError
+        If ``url`` is not provided as a string.
     ValueError
-        If URL is invalid.
+        If ``url`` is an empty or whitespace-only string.
 
     Examples
     --------
@@ -38,7 +40,10 @@ def http_get(
     >>> 'content' in response
     True
     """
-    if not isinstance(url, str) or not url.strip():
+    if not isinstance(url, str):
+        raise TypeError("URL must be a string")
+
+    if not url.strip():
         raise ValueError("URL must be a non-empty string")
 
     # Create request


### PR DESCRIPTION
## Summary
- raise a TypeError when `http_get` receives a non-string URL
- keep ValueError for empty or whitespace-only strings and update the docstring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d1c60f4483258baf4e3954f827f9