### PR TITLE
Add type validation to build_url inputs

### DIFF
--- a/http_functions/build_url.py
+++ b/http_functions/build_url.py
@@ -42,8 +42,10 @@ def build_url(
 
     Raises
     ------
+    TypeError
+        If ``scheme`` or ``hostname`` are not strings.
     ValueError
-        If required parameters are invalid.
+        If required parameters are empty strings.
 
     Examples
     --------
@@ -52,10 +54,14 @@ def build_url(
     >>> build_url('https', 'example.com', query_params={'q': 'search', 'page': '1'})
     'https://example.com?q=search&page=1'
     """
-    if not isinstance(scheme, str) or not scheme.strip():
+    if not isinstance(scheme, str):
+        raise TypeError("Scheme must be a string")
+    if not scheme.strip():
         raise ValueError("Scheme must be a non-empty string")
 
-    if not isinstance(hostname, str) or not hostname.strip():
+    if not isinstance(hostname, str):
+        raise TypeError("Hostname must be a string")
+    if not hostname.strip():
         raise ValueError("Hostname must be a non-empty string")
 
     # Build netloc


### PR DESCRIPTION
## Summary
- raise `TypeError` when the scheme or hostname are not strings before existing value checks
- document the new type validation behavior in the `build_url` docstring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d1cb515c8325beac596f387d0b40