### PR TITLE
Handle missing INI files in parse_ini_config

### DIFF
--- a/env_config_functions/parse_ini_config.py
+++ b/env_config_functions/parse_ini_config.py
@@ -45,7 +45,9 @@ def parse_ini_config(
     >>> parse_ini_config('config.ini', schema_validator=schema)
     """
     parser = configparser.ConfigParser()
-    parser.read(path)
+    files_read = parser.read(path)
+    if not files_read:
+        raise FileNotFoundError(f"INI configuration file not found: {path}")
     config = {section: dict(parser.items(section)) for section in parser.sections()}
     if required_sections:
         missing = [s for s in required_sections if s not in config]

--- a/pytest/unit/env_config_functions/test_parse_ini_config.py
+++ b/pytest/unit/env_config_functions/test_parse_ini_config.py
@@ -48,3 +48,12 @@ def test_parse_ini_config_schema_validator(tmp_path):
     write_ini_file(data, config_file)
     with pytest.raises(ValueError, match="section2 required"):
         parse_ini_config(str(config_file), schema_validator=schema)
+
+
+def test_parse_ini_config_file_not_found(tmp_path):
+    """Test that missing INI files raise FileNotFoundError."""
+
+    missing_file = tmp_path / "missing.ini"
+
+    with pytest.raises(FileNotFoundError):
+        parse_ini_config(str(missing_file))


### PR DESCRIPTION
## Summary
- raise FileNotFoundError when parse_ini_config cannot read the requested INI file
- add a unit test to confirm FileNotFoundError is raised for missing files

## Testing
- pytest pytest/unit/env_config_functions/test_parse_ini_config.py *(fails: ModuleNotFoundError: No module named 'toml')*

------
https://chatgpt.com/codex/tasks/task_e_68d9481964a08325a8344aac4ed2ec49