### PR TITLE
Ensure UnionFind.find initializes new elements

### DIFF
--- a/data_types/union_find.py
+++ b/data_types/union_find.py
@@ -43,9 +43,14 @@ class UnionFind(Generic[T]):
         T
             The representative (root) of the set containing the element.
         """
-        if self.parent.get(element) != element:
-            self.parent[element] = self.find(self.parent[element])
-        return self.parent.get(element, element)
+        parent = self.parent.setdefault(element, element)
+        if element not in self.rank:
+            self.rank[element] = 0
+
+        if parent != element:
+            self.parent[element] = self.find(parent)
+
+        return self.parent[element]
 
     def union(self, element1: T, element2: T) -> None:
         """

--- a/pytest/unit/data_types/test_union_find.py
+++ b/pytest/unit/data_types/test_union_find.py
@@ -1,0 +1,17 @@
+from data_types.union_find import UnionFind
+
+
+def test_find_initializes_new_element():
+    uf: UnionFind[int] = UnionFind()
+
+    assert uf.find(42) == 42
+    # Calling find again should return the same representative without raising
+    assert uf.find(42) == 42
+
+
+def test_find_handles_multiple_new_elements():
+    uf: UnionFind[str] = UnionFind()
+
+    assert uf.find("alpha") == "alpha"
+    assert uf.find("beta") == "beta"
+    assert not uf.connected("alpha", "beta")


### PR DESCRIPTION
## Summary
- ensure `UnionFind.find` creates parent and rank entries for unseen elements before path compression
- add unit tests verifying `find` works on new instances without prior unions

## Testing
- pytest pytest/unit/data_types/test_union_find.py *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68d9481ecef48325907377343a903c36